### PR TITLE
apply black formatting

### DIFF
--- a/lambda_functions/transform_lambda.py
+++ b/lambda_functions/transform_lambda.py
@@ -11,14 +11,15 @@ default_keys_to_remove = ["metric_stream_name", "account_id", "region"]
 EXPECTED_NAMESPACES = ["AWS/S3", "AWS/ES", "AWS/RDS", "AWS/ElastiCache"]
 
 
-@lru_cache(maxsize=1)  
+@lru_cache(maxsize=1)
 def get_clients(region):
     return {
-        's3': boto3.client("s3", region_name=region),
-        'es': boto3.client("es", region_name=region),
-        'rds': boto3.client("rds", region_name=region),
-        'elasticache': boto3.client("elasticache", region_name=region)
+        "s3": boto3.client("s3", region_name=region),
+        "es": boto3.client("es", region_name=region),
+        "rds": boto3.client("rds", region_name=region),
+        "elasticache": boto3.client("elasticache", region_name=region),
     }
+
 
 def lambda_handler(event, context):
     output_records = []
@@ -27,10 +28,10 @@ def lambda_handler(event, context):
     account_id = os.environ.get("ACCOUNT_ID")
     # Get cached clients
     clients = get_clients(region)
-    s3_client = clients['s3']
-    es_client = clients['es']
-    rds_client = clients['rds']
-    redis_client = clients['elasticache']
+    s3_client = clients["s3"]
+    es_client = clients["es"]
+    rds_client = clients["rds"]
+    redis_client = clients["elasticache"]
     try:
         for record in event["records"]:
             pre_json_value = base64.b64decode(record["data"])

--- a/tests/test_transform_lambda.py
+++ b/tests/test_transform_lambda.py
@@ -140,13 +140,18 @@ class TestLambdaHandler:
 
     def test_lambda_handler_many_rds_metric_lines(self, monkeypatch):
         """Test processing multiple metric lines in one record"""
-        
+
         # Clear the LRU cache before test
-        from lambda_functions.transform_lambda import get_clients, get_tags_from_arn, get_rds_description
+        from lambda_functions.transform_lambda import (
+            get_clients,
+            get_tags_from_arn,
+            get_rds_description,
+        )
+
         get_clients.cache_clear()
-        get_tags_from_arn.cache_clear() 
+        get_tags_from_arn.cache_clear()
         get_rds_description.cache_clear()
-        
+
         metrics = [
             {
                 "timestamp": 1640995200000,
@@ -185,13 +190,13 @@ class TestLambdaHandler:
                 "unit": "Percent",
             },
         ]
-        
+
         # Create newline-delimited JSON
         ndjson_data = "\n".join([json.dumps(metric) for metric in metrics]) + "\n"
         encoded_data = base64.b64encode(ndjson_data.encode("utf-8")).decode("utf-8")
         event = {"records": [{"recordId": "multi-metric-record", "data": encoded_data}]}
         context = MagicMock()
-        
+
         # Create a stubbed rds client
         rds_client = boto3.client("rds", region_name=dummy_region)
         stubber = Stubber(rds_client)
@@ -210,7 +215,7 @@ class TestLambdaHandler:
             "DBInstanceIdentifier": "cg-aws-broker-prodjasontest"
         }
         fake_describe = {"DBInstances": [{"AllocatedStorage": 100}]}
-        
+
         # Only stub once per unique call - cache handles the rest
         stubber.add_response(
             "list_tags_for_resource", fake_tags, expected_param_for_stub
@@ -218,19 +223,19 @@ class TestLambdaHandler:
         stubber.add_response(
             "describe_db_instances", fake_describe, expected_param_for_describe
         )
-        
+
         stubber.activate()
         monkeypatch.setenv("AWS_REGION", "us-gov-west-1")
         monkeypatch.setenv("ACCOUNT_ID", "123456")
-        
+
         with patch("lambda_functions.transform_lambda.logger"), patch(
             "boto3.client", return_value=rds_client
         ):
             result = lambda_handler(event, context)
-        
+
         assert len(result["records"]) == 1
         assert result["records"][0]["result"] == "Ok"
-        
+
         # Decode and verify multiple metrics
         output_data = base64.b64decode(result["records"][0]["data"]).decode("utf-8")
         output_metrics = [json.loads(line) for line in output_data.strip().split("\n")]


### PR DESCRIPTION
## Changes proposed in this pull request:

- apply black formatting

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just updating code formatting
